### PR TITLE
Edit resources methods for atmosphere

### DIFF
--- a/core_code/astro_diagnostics.py
+++ b/core_code/astro_diagnostics.py
@@ -11,6 +11,8 @@ class ProjectileDiagnostic(Diagnostic):
     def inspect_resource(self, resource):
         if "Projectile:" + self.component in resource:
             self.data = resource["Projectile:" + self.component]
+        if "Atmosphere:" + self.compoennt in resource:
+            self.data = resource["Atmospehre:" + self.component]
 
     def diagnose(self):
         self.output_function(self.data[0, :])

--- a/core_code/atmos_module.py
+++ b/core_code/atmos_module.py
@@ -20,6 +20,12 @@ class AtmosModule(PhysicsModule):
             h += self.step
         self.altitude[:] = np.array(temp)
         self.density[:], self.temperature[:], self.pressure[:] = coesa76(temp)
+        
+    def exchange_resources(self):
+        self.publish_resource({"Atmosphere:Altitude": self.altitude})
+        self.publish_resource({"Atmosphere:Density": self.density})
+        self.publish_resource({"Atmosphere:Pressure": self.pressure})
+        self.publish_resource({"Atmosphere:Temperature": self.temperature})
 
     def update(self):
         pass            #I don't think we need to run update, but it needs to be instantiated


### PR DESCRIPTION
Adds exchange_resources method for atmosphere PhysicsModule and edits the inspect_resources method in ComputeTool to accommodate for the previous change.

Relevant issues #9 