### PR TITLE
Implement tests for Leapfrog ComputeTool

### DIFF
--- a/tests/test_astrotools.py
+++ b/tests/test_astrotools.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 from turbopy import Simulation, ComputeTool
-from TurboPy-Atmospheric.astro_tools import Leapfrog
+from turbopy_atmospheric.astro_tools import Leapfrog
 from pyatmos import coesa76
 
 def test_init_should_create_object():
@@ -28,7 +28,6 @@ def test_straight_fall():
     pos_init[:] = [[0], [1000]]
     vel_init = np.zeros((2,1))
     vel_init[:] = [[0],[0]]
-    clock = input_data["Clock"]
 
     for x in range(100):
         leap_tester.push(pos_init, vel_init, mass, 0, 0, 1)
@@ -39,3 +38,36 @@ def test_straight_fall():
     assert np.allclose(pos_init, pos_final, rtol = .001, atol = .01)
     assert np.allclose(vel_init, vel_final, rtol = .001, atol = .01)
 
+    for x in range(1300):
+        leap_tester.push(pos_init, vel_init, mass, 0, 0, 1)
+
+    assert pos_init[0, 1] > 0
+
+    for x in range(50):
+        leap_tester.push(pos_init, vel_init, mass, 0, 0, 1)
+
+    assert pos_init[0, 1] == 0
+
+def test_drag_exists():
+    """Tests that drag will slow velocity given a fast-moving projectile"""
+
+
+    input_data = {"Clock": {"start_time": 0, "end_time": 1, "dt": 10 ** -4},
+                  "type": "Leapfrog",
+                  "Grid": {"N": 1, "min": 0, "max": 1},
+                  "PhysicsModules": {}}
+    owner = Simulation(input_data)
+    owner.prepare_simulation()
+    drag_test = Leapfrog(owner, input_data)
+    mass = 50
+    pos_init = np.zeros((2,1))
+    vel.init = np.zeros((2,1))
+    pos_init[:] = [[0], [1000]]
+    vel_init[:] = [[5000], [0]]
+
+    density, filler_temp, pressure = coesa76([1])
+
+    for x in range(100):
+        drag_test.push(pos_init, vel_init, mass, .75, pressure[0], 10)
+
+    assert vel_init[0, 0] < 5000


### PR DESCRIPTION
I've had some local trouble with import statements (beyond the project-breaking syntax error), so could you make sure this works properly?

Two tests for the Leapfrog ComputeTool (one for gravitational acceleration, one for drag)

Drag test may need to be made more precise.