### PR TITLE
Set .gitignore to ignore outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,10 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-<<<<<<< HEAD
 # Ignore simulation outputs
 output_atmos/
-=======
-# Ignore outputs from the simulation
-core_code/output_atmos/**
->>>>>>> cad2438a2af52fded960f68e043eb09393b94295


### PR DESCRIPTION
This adds the output_atmos/ directory to the .gitignore file so that git will not attempt to commit the outputs of the simulation after it is run.

Relevant Issues: #17 