### PR TITLE
Fix typos in astro_physics and test_astrotools

### DIFF
--- a/core_code/astro_physics.py
+++ b/core_code/astro_physics.py
@@ -41,9 +41,9 @@ class Projectile(PhysicsModule):
         self.publish_resource({"Projectile:Velocity": self.velocity})
         self.publish_resource({"Projectile:F_drag": self.f_drag})
         self.publish_resource({"Projectile:Mass": self.mass}
-    
+
     def update(self):
         self.p_h = self.density.get(int((self.position[0, 1]/self.step)))
         self.mach = self.sound_constant * math.sqrt(self.temperature.get(int((self.position[0, 1]/self.step))))
-        self.mach /= math.sqrt((self.velocity[0 , 0] ** 2) + (self.velocity[0, 1] ** 2))
+        self.mach =  math.sqrt((self.velocity[0 , 0] ** 2) + (self.velocity[0, 1] ** 2))/self.mach
         self.push(self.position, self.velocity, self.mass, self.c_d, self.p_h, self.area)

--- a/tests/test_astrotools.py
+++ b/tests/test_astrotools.py
@@ -61,7 +61,7 @@ def test_drag_exists():
     drag_test = Leapfrog(owner, input_data)
     mass = 50
     pos_init = np.zeros((2,1))
-    vel.init = np.zeros((2,1))
+    vel_init = np.zeros((2,1))
     pos_init[:] = [[0], [1000]]
     vel_init[:] = [[5000], [0]]
 


### PR DESCRIPTION
Change the order of division in astro_physics to be a reciprocal for mach number calculation and change a period to an underscore in a variable name in test_astrotools.